### PR TITLE
feat: added a config menu and service and option to automatically display tt answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,18 +226,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.13.0"
-      }
-    },
     "node_modules/@angular-devkit/build-angular/node_modules/@vitejs/plugin-basic-ssl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.1.0.tgz",
@@ -309,6 +297,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -334,6 +323,7 @@
       "integrity": "sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.38",
@@ -503,6 +493,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-18.1.3.tgz",
       "integrity": "sha512-jF4jGHZxV/REnymB11wg5q/DMXewJ0byihmvNQ3OPLHGkWnvE9MdrX44vUzI7RkzqO0suaAg8shxJlkY3OHjeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -584,18 +575,6 @@
         }
       }
     },
-    "node_modules/@angular/build/node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.13.0"
-      }
-    },
     "node_modules/@angular/build/node_modules/@vitejs/plugin-basic-ssl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.1.0.tgz",
@@ -615,6 +594,7 @@
       "integrity": "sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.38",
@@ -670,6 +650,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.1.3.tgz",
       "integrity": "sha512-u14xbuXQz+36nBeHSwRcwRoS64WNhOdK97H47nI1WaIZZaGGvKHR1Wwk2XletDRtIHv2622sJm8h+dbaBNeTGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -721,6 +702,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-18.1.3.tgz",
       "integrity": "sha512-TC71jVph4L+QaXlyJTrW27nbqis4sWwr9hD/RDSNkfY9XCvYDb2MjYjKrpbN03FWiv7lmcKT9zgse1fYENFsKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -737,6 +719,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-18.1.3.tgz",
       "integrity": "sha512-Mrcd+YGsz02GVnVlVbzYp7EJIVoPOIHMvhll1OiylhjQElNVeJCLPIvjVYdylzOUDctXNlchkGf/LbA7BYMbXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -758,6 +741,7 @@
       "integrity": "sha512-e9t5v/L1KqPLUQL+WU+d70MBBFcSRuwqbkluZgdDjdW5VelYjzlVzXdrzV6jFElP48T3kQCxJN1dAJkAvKjdOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.24.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -850,6 +834,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-18.1.3.tgz",
       "integrity": "sha512-1tFTyGLwio5oYAP2sMVDiOvy5wl/v0a4om7RTCpP2Bjro0ynuYe8FK7ilcmdyPXR1DF7GVdo/0R/eCIQJZ2PwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -866,6 +851,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-18.1.3.tgz",
       "integrity": "sha512-4kic/9hpS0HkbTORIkrdox7K40EcVT9VIbBruPoxX7jbfiW5jFaJ/05hLRvRt9RF8Sd9G+g5Uohmkcq/5hmsng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -902,6 +888,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-18.1.3.tgz",
       "integrity": "sha512-/k5Xt/WjOk6OlRqb1Wd0ZUQ3NjSbafQyDC9Icy0Mb8qJtiXZjA4VCMkZIiQD7cBxO0F/BsAiYnYNjWrIkCZICA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -985,6 +972,7 @@
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -3547,6 +3535,7 @@
       "integrity": "sha512-GFcigCxJTKCH3aECzMIu4FhgLJWnFvMXzpI4CCSoELWFtkOOU2P+goYA61+OKpGrB8fPE7q6n8zAXBSlZRrHjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^2.3.7",
         "@inquirer/confirm": "^3.1.11",
@@ -5445,6 +5434,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5894,6 +5884,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -9157,7 +9148,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
       "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -9312,6 +9304,7 @@
       "integrity": "sha512-HRNQhMuKOwKpjYlWiJP0DUrJOh+QjaI/DTaD8b9rEm4Il3tJ8MijutVZH4ts10LuUFst/CedwTS6vieCN8yTSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -9405,6 +9398,7 @@
       "integrity": "sha512-ggi84RMNQffSDmWSyyt4zxzh2CQGwsxvYYsprgyR1j8ikzIduEdOlcLvXjZGwXG/0j41KUXOWsUCBfbEHPWP9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^3.6.0"
       },
@@ -9618,6 +9612,7 @@
       "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -11826,6 +11821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -12638,6 +12634,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
       "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "~2.1.0"
       }
@@ -12691,6 +12688,7 @@
       "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -13711,6 +13709,7 @@
       "integrity": "sha512-1SEOvRr6sSdV5IDf9iC+NU4dhwdqzF4zKKq3sAbasUWHEM6lsMhX+eNN5gkPx1BvLFEnZQEUFbXnGj8Qlp83Pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13846,6 +13845,7 @@
       "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -13900,6 +13900,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14094,7 +14095,8 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "2.2.1",
@@ -14151,6 +14153,7 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14514,6 +14517,7 @@
       "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -14592,6 +14596,7 @@
       "integrity": "sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -14787,6 +14792,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14810,6 +14816,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15275,7 +15282,8 @@
       "version": "0.14.10",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
       "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -1,15 +1,13 @@
 <div class="w-full h-full">
   <mat-toolbar>
-    <a
-      mat-icon-button
-      routerLink="/"
-
-      title="Quay về màn hình chính"
-    >
+    <a mat-icon-button routerLink="/" title="Quay về màn hình chính">
       <mat-icon>home</mat-icon>
     </a>
     <button mat-icon-button (click)="togglePoints()" title="Điểm số">
       <mat-icon>scoreboard</mat-icon>
+    </button>
+    <button mat-icon-button (click)="openConfigMenu()" title="Cấu hình">
+      <mat-icon>settings</mat-icon>
     </button>
     <span class="flex flex-grow"></span>
     <a mat-icon-button routerLink="/admin" title="Trang chủ">
@@ -30,6 +28,7 @@
     <a mat-icon-button routerLink="/admin/chp" title="Câu hỏi phụ">
       <mat-icon>workspaces</mat-icon>
     </a>
+
   </mat-toolbar>
   <router-outlet></router-outlet>
 </div>

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -2,6 +2,9 @@ import { Component } from "@angular/core";
 import { getControlUrlFromMatchPosition } from "../services/tools";
 import { Router } from "@angular/router";
 import { AuthService } from "../services/auth.service";
+import { MatDialog } from "@angular/material/dialog";
+import { FormConfigComponent } from "../components/forms/form-config/form-config.component";
+import { ConfigService } from "../services/config.service";
 
 @Component({
   selector: "app-admin",
@@ -9,7 +12,7 @@ import { AuthService } from "../services/auth.service";
   styleUrl: "./admin.component.scss",
 })
 export class AdminComponent {
-  constructor(private router: Router, public auth: AuthService) {}
+  constructor(private router: Router, public auth: AuthService, private dialog: MatDialog, private config: ConfigService) {}
   changeMatchPosAdmin(pos: string) {
     this.router.navigate([getControlUrlFromMatchPosition(pos)]);
   }
@@ -33,6 +36,18 @@ export class AdminComponent {
           "PNTS",
           localStorage.getItem("authString")
         );
+      }
+    });
+  }
+  
+  openConfigMenu() {
+    const dialogRef = this.dialog.open(FormConfigComponent, {
+      width: "400px",
+      data: this.config.config()
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.config.config.set(result);
       }
     });
   }

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -21,6 +21,8 @@ import { MatProgressSpinner } from "@angular/material/progress-spinner";
 import { AdminComponent } from "./admin.component";
 import { AdminDashboardComponent } from "./dashboard/dashboard.component";
 import { MatTooltipModule } from "@angular/material/tooltip";
+import { MatDividerModule } from '@angular/material/divider';
+
 
 export const adminRoutes: Routes = [
   {
@@ -86,9 +88,10 @@ export const adminRoutes: Routes = [
     MatProgressSpinner,
     MatToolbarModule,
     MatTooltipModule,
-    MatExpansionModule
+    MatExpansionModule,
+    MatDividerModule
   ],
   bootstrap: [AdminComponent],
   exports: [RouterModule],
 })
-export class AdminModule {}
+export class AdminModule { }

--- a/src/app/admin/control-tangtoc/control-tangtoc.component.ts
+++ b/src/app/admin/control-tangtoc/control-tangtoc.component.ts
@@ -5,6 +5,7 @@ import { FormPlayerComponent } from "../../components/forms/form-player/form-pla
 import { FormQTtComponent } from "../../components/forms/form-q-tt/form-q-tt.component";
 import { AuthService } from "../../services/auth.service";
 import { TtData, TtQuestion } from "../../services/types/game";
+import { ConfigService } from "src/app/services/config.service";
 
 @Component({
   selector: "app-control-tangtoc",
@@ -15,8 +16,9 @@ export class ControlTangtocComponent implements OnInit {
   constructor(
     private router: Router,
     public dialog: MatDialog,
-    public auth: AuthService
-  ) {}
+    public auth: AuthService,
+    private config: ConfigService
+  ) { }
   ifPlayerCNV: boolean = true;
   tangtocData: TtData | undefined;
   currentTime: number = 0;
@@ -78,9 +80,9 @@ export class ControlTangtocComponent implements OnInit {
   editQuestion() {
     let question =
       this.tangtocData!.questions[
-        this.tangtocData!.questions.indexOf(
-          this.chosenRow || ({} as TtQuestion)
-        )
+      this.tangtocData!.questions.indexOf(
+        this.chosenRow || ({} as TtQuestion)
+      )
       ];
     const dialogRef = this.dialog.open(FormQTtComponent, {
       data: question,
@@ -155,6 +157,11 @@ export class ControlTangtocComponent implements OnInit {
       this.auth.socket.emit("change-match-position", "TT_A");
     } else if (this.auth.matchData().matchPos == "TT_A") {
       this.auth.socket.emit("change-match-position", "TT_Q");
+      if (this.config.config().automaticallyShowTangTocAnswer && this.tangtocData?.questions[this.displayingRow?.id || -1].answer_image) {
+        this.tangtocData!.showAnswer = true;
+        this.auth.socket.emit("update-tangtoc-data", this.tangtocData);
+        setTimeout(() => this.auth.socket.emit("broadcast-tt-question", this.displayingRow?.id || -1));
+      }
       if (this.tangtocData!.showResults == true) this.toggleResultsDisplay();
     }
   }

--- a/src/app/components/forms/form-config/form-config.component.html
+++ b/src/app/components/forms/form-config/form-config.component.html
@@ -1,0 +1,11 @@
+<h1 mat-dialog-title>Sửa cấu hình ứng dụng</h1>
+<div mat-dialog-content>
+    <h5>
+        Phần Thi Tăng tốc
+    </h5>
+    <mat-slide-toggle [(ngModel)]="config.automaticallyShowTangTocAnswer">Tự động hiển thị đáp án</mat-slide-toggle>
+</div>
+<div mat-dialog-actions>
+    <button mat-button (click)="onNoClick()">Huỷ</button>
+    <button mat-button [mat-dialog-close]="config" cdkFocusInitial>Lưu</button>
+</div>

--- a/src/app/components/forms/form-config/form-config.component.ts
+++ b/src/app/components/forms/form-config/form-config.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { FormPlayerComponent } from '../form-player/form-player.component';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { ApplicationConfig } from 'src/app/services/config.service';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+
+@Component({
+  selector: 'app-form-config',
+  standalone: true,
+  templateUrl: './form-config.component.html',
+  imports: [
+    MatFormFieldModule,
+    FormsModule,
+    MatDialogModule,
+    MatSlideToggleModule,
+    MatButtonModule
+  ]
+})
+export class FormConfigComponent {
+  constructor(
+    public dialogRef: MatDialogRef<FormConfigComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ApplicationConfig
+  ) { }
+  public config: ApplicationConfig = { ...this.data };
+  ngOnInit(): void {
+  }
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/components/forms/form-player/form-player.component.ts
+++ b/src/app/components/forms/form-player/form-player.component.ts
@@ -8,7 +8,6 @@ import { MatInputModule } from '@angular/material/input';
 @Component({
   selector: 'app-form-player',
   templateUrl: './form-player.component.html',
-  styleUrls: ['./form-player.component.scss'],
   standalone: true,
   imports: [
     MatFormFieldModule,

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,0 +1,29 @@
+import { effect, Injectable, signal, WritableSignal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+  public readonly config: WritableSignal<ApplicationConfig> = signal(this.loadConfig());
+  constructor() {
+
+    effect(() => {
+      localStorage.setItem("appConfig", JSON.stringify(this.config()));
+    })
+  }
+
+  private loadConfig(): ApplicationConfig {
+    const defaultConfig: ApplicationConfig = {
+      automaticallyShowTangTocAnswer: true
+    };
+    try {
+      return JSON.parse(localStorage.getItem("appConfig") ?? "") as ApplicationConfig || defaultConfig;
+    } catch (error) {
+      return defaultConfig;
+    }
+  }
+}
+
+export type ApplicationConfig = {
+  automaticallyShowTangTocAnswer: boolean
+}


### PR DESCRIPTION
This pull request introduces a new application-wide configuration system, allowing admins to adjust settings through a dialog in the admin UI. The main feature added is the ability to toggle automatic answer display for the "Tăng tốc" game section. The configuration is persisted in local storage and is applied in relevant game logic. Additional UI and dependency updates support these features.

**New Configuration System**

* Added `ConfigService` (`config.service.ts`) to manage application settings with local storage persistence and a signal-based API. The initial setting is `automaticallyShowTangTocAnswer`.
* Created `FormConfigComponent` (`form-config.component.ts`/`.html`) as a dialog for editing configuration, currently allowing toggling of automatic answer display for "Tăng tốc". [[1]](diffhunk://#diff-46fe372196ee4e3daf07b61791407c442a7685b621012308430bb0c51de1e296R1-R33) [[2]](diffhunk://#diff-06aa6f62d4726339cbe252692ee3ba4a9e5e0cdc77755652ed809e579b8105c0R1-R11)

**Admin UI Enhancements**

* Added a "Cấu hình" (Settings) button to the admin toolbar that opens the configuration dialog.
* Updated `AdminComponent` to inject and use `ConfigService` and open the config dialog. [[1]](diffhunk://#diff-54397c95bc577d52c65363401d9886f6e709680d78024193377bd86448a369b1R5-R15) [[2]](diffhunk://#diff-54397c95bc577d52c65363401d9886f6e709680d78024193377bd86448a369b1R42-R53)
* Registered necessary Angular Material modules for the new dialog in `admin.module.ts`. [[1]](diffhunk://#diff-99a56a29c0ab686c2eaa0cffcd213904eb800204a97c581839799a193190f3a0R24-R25) [[2]](diffhunk://#diff-99a56a29c0ab686c2eaa0cffcd213904eb800204a97c581839799a193190f3a0L89-R92)

**Game Logic Integration**

* Updated `ControlTangtocComponent` to inject `ConfigService` and use the `automaticallyShowTangTocAnswer` setting to control answer visibility and broadcasting in the "Tăng tốc" section. [[1]](diffhunk://#diff-88bfc6611ad7ab6a038e39ec939e85bff124ea457e73bbb65770f5a4b155ca76R8) [[2]](diffhunk://#diff-88bfc6611ad7ab6a038e39ec939e85bff124ea457e73bbb65770f5a4b155ca76L18-R20) [[3]](diffhunk://#diff-88bfc6611ad7ab6a038e39ec939e85bff124ea457e73bbb65770f5a4b155ca76R160-R164)
